### PR TITLE
Refactor to force passing in webpack config directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ becomes
 ```Json
 {
   "scripts": {
-    "hot": "./client/node_modules/atomic-reactor/webpack.hot.js"
+    "hot": "node ./node_modules/atomic-reactor/webpack.hot.js --configDir=client/config"
   }
 }
 ```

--- a/build.js
+++ b/build.js
@@ -1,6 +1,10 @@
-const apps = require('./build/apps');
-const log = require('./build/log');
 const argv = require('minimist')(process.argv.slice(2));
+
+const configDir = argv.configDir;
+const settings = require('./build/settings')(configDir);
+
+const apps = require('./build/apps')(settings);
+const log = require('./build/log');
 
 const stage = argv.release ? 'production' : 'development';
 const port = parseInt(process.env.ASSETS_PORT, 10) || 8080;

--- a/build/apps.js
+++ b/build/apps.js
@@ -1,64 +1,65 @@
 const fs = require('fs-extra');
 const _ = require('lodash');
 const webpack = require('webpack');
-const settings = require('./settings');
 const webpackConfigBuilder = require('../webpack.config');
 
-// clean up old build
-function clean(apps, options) {
-  // Clean dirs
-  if (!options.noClean) {
-    _.each(apps, (app) => {
-      fs.emptyDirSync(app.outputPath);
-    });
+module.exports = function appsBuilder(settings) {
+  // clean up old build
+  function clean(apps, options) {
+    // Clean dirs
+    if (!options.noClean) {
+      _.each(apps, (app) => {
+        fs.emptyDirSync(app.outputPath);
+      });
+    }
   }
-}
 
-// -----------------------------------------------------------------------------
-// Build a single app
-// -----------------------------------------------------------------------------
-function buildApp(appName, options) {
-  const apps = settings.apps(options);
-  const app = _.find(apps, (e, name) => appName === name);
-  const webpackCompiler = webpack(webpackConfigBuilder(app, options));
+  // -----------------------------------------------------------------------------
+  // Build a single app
+  // -----------------------------------------------------------------------------
+  function buildApp(appName, options) {
+    const apps = settings.apps(options);
+    const app = _.find(apps, (e, name) => appName === name);
+    const webpackCompiler = webpack(webpackConfigBuilder(app, options));
 
-  clean([app], options);
+    clean([app], options);
+
+    return {
+      app,
+      webpackCompiler
+    };
+  }
+
+  function buildAppsForMultipleServers(options) {
+    const apps = settings.apps(options);
+    clean(apps, options);
+    return _.map(apps, app => ({
+      app,
+      webpackCompiler: webpack(webpackConfigBuilder(app, options))
+    }));
+  }
+
+  // -----------------------------------------------------------------------------
+  // Build all apps
+  // -----------------------------------------------------------------------------
+  function buildAppsForOneServer(options) {
+    const apps = settings.apps(options);
+    clean(apps, options);
+    const webpackConfigs = _(apps)
+      .sortBy((app) => { return app.options.onlyPack ? 0 : 1; })
+      .map(app => webpackConfigBuilder(app, options))
+      .value();
+    const webpackCompiler = webpack(webpackConfigs);
+
+    return {
+      apps,
+      webpackCompiler
+    };
+  }
 
   return {
-    app,
-    webpackCompiler
+    buildApp,
+    buildAppsForMultipleServers,
+    buildAppsForOneServer
   };
-}
-
-function buildAppsForMultipleServers(options) {
-  const apps = settings.apps(options);
-  clean(apps, options);
-  return _.map(apps, app => ({
-    app,
-    webpackCompiler: webpack(webpackConfigBuilder(app, options))
-  }));
-}
-
-// -----------------------------------------------------------------------------
-// Build all apps
-// -----------------------------------------------------------------------------
-function buildAppsForOneServer(options) {
-  const apps = settings.apps(options);
-  clean(apps, options);
-  const webpackConfigs = _(apps)
-    .sortBy((app) => { return app.options.onlyPack ? 0 : 1; })
-    .map(app => webpackConfigBuilder(app, options))
-    .value();
-  const webpackCompiler = webpack(webpackConfigs);
-
-  return {
-    apps,
-    webpackCompiler
-  };
-}
-
-module.exports = {
-  buildApp,
-  buildAppsForMultipleServers,
-  buildAppsForOneServer
 };

--- a/build/settings.js
+++ b/build/settings.js
@@ -3,208 +3,209 @@ const path = require('path');
 const _ = require('lodash');
 
 const utils = require('./utils');
-const configDir = '../../../config';
 
-const {
-  paths,
-  hotPort,
-  devOutput,
-  prodOutput,
-  buildSuffix,
-  htmlOptions,
-  templateData, // Object that will be passed to every page as it is rendered
-  templateMap, // Used to specify specific templates on a per file basis
-  themeTemplateDirs
-} = require(`${configDir}/settings`);
+module.exports = function settingsBuilder(configDir) {
+  const {
+    paths,
+    hotPort,
+    devOutput,
+    prodOutput,
+    buildSuffix,
+    htmlOptions,
+    templateData, // Object that will be passed to every page as it is rendered
+    templateMap, // Used to specify specific templates on a per file basis
+    themeTemplateDirs
+  } = require(`${configDir}/settings`);
 
-// -----------------------------------------------------------------------------
-// Helper function to generate full template paths for the given app
-// -----------------------------------------------------------------------------
-function templateDirs(app, dirs) {
-  return _.map(dirs, templateDir => path.join(app.htmlPath, templateDir));
-}
-
-// -----------------------------------------------------------------------------
-// Helper to determine if we should do a production build or not
-// -----------------------------------------------------------------------------
-function isProduction(stage) {
-  return stage === 'production' || stage === 'staging';
-}
-
-function isNameRequired(options) {
-  return !options.onlyPack && !options.rootOutput;
-}
-
-// -----------------------------------------------------------------------------
-// Generates a path with the app name if needed
-// -----------------------------------------------------------------------------
-function withNameIfRequired(name, relativeOutput, options) {
-  if (isNameRequired(options) && !options.appPerPort) {
-    return utils.joinUrlOrPath(relativeOutput, name);
+  // -----------------------------------------------------------------------------
+  // Helper function to generate full template paths for the given app
+  // -----------------------------------------------------------------------------
+  function templateDirs(app, dirs) {
+    return _.map(dirs, templateDir => path.join(app.htmlPath, templateDir));
   }
-  return relativeOutput;
-}
 
-// -----------------------------------------------------------------------------
-// Generates the main paths used for output
-// -----------------------------------------------------------------------------
-function outputPaths(name, port, appPath, options) {
+  // -----------------------------------------------------------------------------
+  // Helper to determine if we should do a production build or not
+  // -----------------------------------------------------------------------------
+  function isProduction(stage) {
+    return stage === 'production' || stage === 'staging';
+  }
 
-  const outName = options.name || name;
+  function isNameRequired(options) {
+    return !options.onlyPack && !options.rootOutput;
+  }
 
-  let rootOutputPath = devOutput;
-  let outputPath = isNameRequired(options) ? path.join(devOutput, outName) : devOutput;
-  // Public path indicates where the assets will be served from. In dev this will likely be
-  // localhost or a local domain. In production this could be a CDN. In development this will
-  // point to whatever public url is serving dev assets.
-
-  let publicPath;
-
-  if (isProduction(options.stage)) {
-    rootOutputPath = prodOutput;
-    outputPath = isNameRequired(options) ? path.join(prodOutput, outName) : prodOutput;
-    publicPath = utils.joinUrlOrPath(
-      paths.prodAssetsUrl,
-      withNameIfRequired(outName, paths.prodRelativeOutput, options)
-    );
-  } else {
-    let devUrl = paths.devAssetsUrl;
-    // Include the port if we are running on localhost
-    if (_.find(['localhost', '0.0.0.0', '127.0.0.1'], d => _.includes(paths.devAssetsUrl, d))) {
-      devUrl = `${paths.devAssetsUrl}:${port}`;
+  // -----------------------------------------------------------------------------
+  // Generates a path with the app name if needed
+  // -----------------------------------------------------------------------------
+  function withNameIfRequired(name, relativeOutput, options) {
+    if (isNameRequired(options) && !options.appPerPort) {
+      return utils.joinUrlOrPath(relativeOutput, name);
     }
-    publicPath = utils.joinUrlOrPath(
-      devUrl,
-      withNameIfRequired(outName, paths.devRelativeOutput, options)
-    );
+    return relativeOutput;
   }
 
-  // Make sure the public path ends with a / or fonts will not have the correct path
-  if (!_.endsWith(publicPath, '/')) {
-    publicPath = `${publicPath}/`;
+  // -----------------------------------------------------------------------------
+  // Generates the main paths used for output
+  // -----------------------------------------------------------------------------
+  function outputPaths(name, port, appPath, options) {
+
+    const outName = options.name || name;
+
+    let rootOutputPath = devOutput;
+    let outputPath = isNameRequired(options) ? path.join(devOutput, outName) : devOutput;
+    // Public path indicates where the assets will be served from. In dev this will likely be
+    // localhost or a local domain. In production this could be a CDN. In development this will
+    // point to whatever public url is serving dev assets.
+
+    let publicPath;
+
+    if (isProduction(options.stage)) {
+      rootOutputPath = prodOutput;
+      outputPath = isNameRequired(options) ? path.join(prodOutput, outName) : prodOutput;
+      publicPath = utils.joinUrlOrPath(
+        paths.prodAssetsUrl,
+        withNameIfRequired(outName, paths.prodRelativeOutput, options)
+      );
+    } else {
+      let devUrl = paths.devAssetsUrl;
+      // Include the port if we are running on localhost
+      if (_.find(['localhost', '0.0.0.0', '127.0.0.1'], d => _.includes(paths.devAssetsUrl, d))) {
+        devUrl = `${paths.devAssetsUrl}:${port}`;
+      }
+      publicPath = utils.joinUrlOrPath(
+        devUrl,
+        withNameIfRequired(outName, paths.devRelativeOutput, options)
+      );
+    }
+
+    // Make sure the public path ends with a / or fonts will not have the correct path
+    if (!_.endsWith(publicPath, '/')) {
+      publicPath = `${publicPath}/`;
+    }
+
+    return {
+      rootOutputPath,
+      outputPath,
+      publicPath
+    };
   }
 
-  return {
-    rootOutputPath,
-    outputPath,
-    publicPath
-  };
-}
-
-function getWebpackJson(path) {
-  if (fs.existsSync(path)) {
-    return JSON.parse(fs.readFileSync(path, 'utf8'));
-  }
-  return {};
-}
-
-function getWebpackJs(configPath) {
-  try {
-    return (require(configPath))();
-  } catch (e) {
+  function getWebpackJson(path) {
+    if (fs.existsSync(path)) {
+      return JSON.parse(fs.readFileSync(path, 'utf8'));
+    }
     return {};
   }
-}
 
-// -----------------------------------------------------------------------------
-// Generate settings needed for webpack
-// Allow for custom overrides to be placed in webpack.json
-// -----------------------------------------------------------------------------
-function webpackSettings(name, file, appPath, port, options) {
-
-  const customWebpack = _.merge(
-    {},
-    getWebpackJson(`${appPath}/webpack.json`),
-    getWebpackJs(`${appPath}/webpack.js`),
-    getWebpackJson(`${configDir}/webpack.json`),
-    getWebpackJs(`${configDir}/webpack.js`)
-  );
-
-  const production = isProduction(options.stage);
-
-  return {
-    name,
-    file,
-    path: appPath,
-    shouldLint: options.shouldLint,
-    stage: options.stage,
-    production,
-    buildSuffix,
-    port,
-    filename: production ? '[name]-[chunkhash]' : '[name]',
-    chunkFilename: production ? '[id]-[chunkhash]' : '[id]',
-    customWebpack
-  };
-}
-
-// -----------------------------------------------------------------------------
-// Generate all settings needed for a given application
-// -----------------------------------------------------------------------------
-function appSettings(name, port, options) {
-
-  const appPath = path.join(paths.appsDir, name);
-  const htmlPath = path.join(appPath, 'html');
-  const staticPath = path.join(appPath, 'static');
-
-  const customOptionsPath = `${appPath}/options.json`;
-  let combinedOptions = options;
-  if (fs.existsSync(customOptionsPath)) {
-    const customOptions = JSON.parse(fs.readFileSync(customOptionsPath, 'utf8'));
-    combinedOptions = _.merge({}, options, customOptions);
+  function getWebpackJs(configPath) {
+    try {
+      return (require(configPath))();
+    } catch (e) {
+      return {};
+    }
   }
 
-  const app = _.merge({
-    htmlPath,
-    staticPath,
-    templateData: templateData || {},
-    templateMap: templateMap || {},
-    htmlOptions,
-    options: combinedOptions
-  }, webpackSettings(name, 'app.jsx', appPath, port, combinedOptions),
-     outputPaths(name, port, appPath, combinedOptions));
+  // -----------------------------------------------------------------------------
+  // Generate settings needed for webpack
+  // Allow for custom overrides to be placed in webpack.json
+  // -----------------------------------------------------------------------------
+  function webpackSettings(name, file, appPath, port, options) {
 
-  if (themeTemplateDirs) {
-    app.templateDirs = _.union(templateDirs(app, ['layouts']), themeTemplateDirs);
-  } else {
-    app.templateDirs = templateDirs(app, ['layouts']);
-  }
-
-  return {
-    [name] : app
-  };
-}
-
-// -----------------------------------------------------------------------------
-// Iterate a given directory to generate app or webpack settings
-// -----------------------------------------------------------------------------
-function iterateDirAndPorts(dir, options, cb) {
-  let port = options.port;
-  const iteratedApps = fs.readdirSync(dir)
-    .filter(file => fs.statSync(path.join(dir, file)).isDirectory())
-    .reduce((result, appName) => {
-      const app = cb(appName, port, options);
-      port = options.appPerPort ? port + 1 : options.port;
-      return _.merge(result, app);
-    }, {});
-  if (options.order && options.order.length > 0) {
-    return iteratedApps.sort((a, b) =>
-      (options.order.indexOf(a.name) > options.order.indexOf(b.name))
+    const customWebpack = _.merge(
+      {},
+      getWebpackJson(`${appPath}/webpack.json`),
+      getWebpackJs(`${appPath}/webpack.js`),
+      getWebpackJson(`${configDir}/webpack.json`),
+      getWebpackJs(`${configDir}/webpack.js`)
     );
+
+    const production = isProduction(options.stage);
+
+    return {
+      name,
+      file,
+      path: appPath,
+      shouldLint: options.shouldLint,
+      stage: options.stage,
+      production,
+      buildSuffix,
+      port,
+      filename: production ? '[name]-[chunkhash]' : '[name]',
+      chunkFilename: production ? '[id]-[chunkhash]' : '[id]',
+      customWebpack
+    };
   }
-  return iteratedApps;
-}
 
-// -----------------------------------------------------------------------------
-// Generates an app setting for all applications found in the client directory
-// -----------------------------------------------------------------------------
-function apps(options) {
-  return iterateDirAndPorts(paths.appsDir, options, appSettings);
-}
+  // -----------------------------------------------------------------------------
+  // Generate all settings needed for a given application
+  // -----------------------------------------------------------------------------
+  function appSettings(name, port, options) {
 
-module.exports = {
-  paths,
-  outputPaths,
-  apps,
-  hotPort,
-  isProduction
+    const appPath = path.join(paths.appsDir, name);
+    const htmlPath = path.join(appPath, 'html');
+    const staticPath = path.join(appPath, 'static');
+
+    const customOptionsPath = `${appPath}/options.json`;
+    let combinedOptions = options;
+    if (fs.existsSync(customOptionsPath)) {
+      const customOptions = JSON.parse(fs.readFileSync(customOptionsPath, 'utf8'));
+      combinedOptions = _.merge({}, options, customOptions);
+    }
+
+    const app = _.merge({
+      htmlPath,
+      staticPath,
+      templateData: templateData || {},
+      templateMap: templateMap || {},
+      htmlOptions,
+      options: combinedOptions
+    }, webpackSettings(name, 'app.jsx', appPath, port, combinedOptions),
+       outputPaths(name, port, appPath, combinedOptions));
+
+    if (themeTemplateDirs) {
+      app.templateDirs = _.union(templateDirs(app, ['layouts']), themeTemplateDirs);
+    } else {
+      app.templateDirs = templateDirs(app, ['layouts']);
+    }
+
+    return {
+      [name] : app
+    };
+  }
+
+  // -----------------------------------------------------------------------------
+  // Iterate a given directory to generate app or webpack settings
+  // -----------------------------------------------------------------------------
+  function iterateDirAndPorts(dir, options, cb) {
+    let port = options.port;
+    const iteratedApps = fs.readdirSync(dir)
+      .filter(file => fs.statSync(path.join(dir, file)).isDirectory())
+      .reduce((result, appName) => {
+        const app = cb(appName, port, options);
+        port = options.appPerPort ? port + 1 : options.port;
+        return _.merge(result, app);
+      }, {});
+    if (options.order && options.order.length > 0) {
+      return iteratedApps.sort((a, b) =>
+        (options.order.indexOf(a.name) > options.order.indexOf(b.name))
+      );
+    }
+    return iteratedApps;
+  }
+
+  // -----------------------------------------------------------------------------
+  // Generates an app setting for all applications found in the client directory
+  // -----------------------------------------------------------------------------
+  function apps(options) {
+    return iterateDirAndPorts(paths.appsDir, options, appSettings);
+  }
+
+  return {
+    paths,
+    outputPaths,
+    apps,
+    hotPort,
+    isProduction
+  };
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atomic-reactor",
-  "version": "1.1.9",
+  "version": "2.0.0",
   "description": "Atomic Jolt's React build tool",
   "scripts": {
     "test": "./node_modules/jest/bin/jest.js --config=config/jest_config.json",

--- a/server.js
+++ b/server.js
@@ -1,7 +1,11 @@
+const argv = require('minimist')(process.argv.slice(2));
+
+const configDir = argv.configDir;
+
 const path = require('path');
 const express = require('express');
 
-const settings = require('./build/settings');
+const settings = require('./build/settings')(configDir);
 
 const serverApp = express();
 

--- a/webpack.hot.js
+++ b/webpack.hot.js
@@ -5,13 +5,13 @@ const webpackMiddleware = require('webpack-dev-middleware');
 // const webpackHotMiddleware = require('webpack-hot-middleware');
 const path = require('path');
 const argv = require('minimist')(process.argv.slice(2));
-const clientApps = require('./build/apps');
 
 const localIp = '0.0.0.0';
 const appName = argv.app;
 const hotPack = argv.hotPack;
 const shouldLint = argv.lint;
 let rootOutput = argv.rootOutput;
+const configDir = argv.configDir;
 
 let appPerPort = true;
 let onlyPack = false;
@@ -29,10 +29,14 @@ if (hotPack) {
   }
 }
 
+const settings = require('./build/settings')(configDir);
+
 const {
   hotPort,
   paths
-} = require('./build/settings');
+} = settings;
+
+const clientApps = require('./build/apps')(settings);
 
 const options = {
   hotPack,


### PR DESCRIPTION
# BREAKING CHANGE #
* Instead of hard coding the settings config directory, it must be passed in now. ie: `node ./node_modules/atomic-reactor/webpack.hot.js --hotPack --configDir=client/config`
* Bump version to 2.0.0