### PR TITLE
Jd fix hot

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "watch": "jest --config=config/jest_config.json --watch"
   },
   "bin": {
-    "atomic-webpack-hot": "./webpack.hot.js",
+    "atomic-webpack-dev": "./webpack.dev.js",
     "atomic-webpack-server": "./server.js",
     "atomic-webpack-build": "./build.js",
     "atomic-reactor": "./atomic-reactor.js"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -146,17 +146,14 @@ module.exports = function webpackConfig(app, options = {}) {
         openAnalyzer: false
       })
     ]);
+  } else if (app.stage === 'hot') {
+    plugins = _.concat(plugins, [
+      new webpack.HotModuleReplacementPlugin(),
+      new webpack.NoEmitOnErrorsPlugin(),
+    ]);
   }
 
   plugins.push(new HtmlBuilderPlugin(app, options));
-  // TODO fix the hot reload
-  //  else if (app.stage === 'hot') {
-  //   plugins = _.concat(plugins, [
-  //     // new webpack.HotModuleReplacementPlugin(),
-  //     // new webpack.NoEmitOnErrorsPlugin(),
-  //   ]);
-  // }
-
   const rules = [
     { test: /\.js$/, use: jsLoaders, exclude: /node_modules/ },
     { test: /\.jsx?$/, use: jsLoaders, exclude: /node_modules/ },
@@ -176,7 +173,7 @@ module.exports = function webpackConfig(app, options = {}) {
     // Add hot reload to entry
     entry[app.name] = [
       'eventsource-polyfill',
-      // `webpack-hot-middleware/client?name=${app.name}`,
+      `webpack-hot-middleware/client?name=${app.name}`,
       entryPath
     ];
   }

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -14,8 +14,10 @@ const hotPack = argv.hotPack;
 const shouldLint = argv.lint;
 let rootOutput = argv.rootOutput;
 const configDir = argv.configDir;
-const codeSplittingOff = argv.codeSplittingOff;
-const extractCssOff = argv.extractCssOff;
+const hot = argv.hot;
+const codeSplittingOff = argv.codeSplittingOff || hot;
+const extractCssOff = argv.extractCssOff || hot;
+
 
 let appPerPort = true;
 let onlyPack = false;
@@ -45,7 +47,7 @@ const clientApps = require('./build/apps')(settings);
 const options = {
   hotPack,
   shouldLint,
-  stage: 'hot',
+  stage: hot ? 'hot' : 'development',
   onlyPack,
   port:
   hotPort,

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -63,7 +63,9 @@ function setupMiddleware(serverApp, compiler) {
     headers: { 'Access-Control-Allow-Origin': '*' }
   });
   serverApp.use(webpackMiddlewareInstance);
-  serverApp.use(webpackHotMiddleware(compiler))
+  if (hot) {
+    serverApp.use(webpackHotMiddleware(compiler))
+  }
 }
 
 function runServer(serverApp, port, servePath) {

--- a/webpack.hot.js
+++ b/webpack.hot.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 const express = require('express');
 
 const webpackMiddleware = require('webpack-dev-middleware');
-// const webpackHotMiddleware = require('webpack-hot-middleware');
+const webpackHotMiddleware = require('webpack-hot-middleware');
 const path = require('path');
 const argv = require('minimist')(process.argv.slice(2));
 
@@ -14,6 +14,8 @@ const hotPack = argv.hotPack;
 const shouldLint = argv.lint;
 let rootOutput = argv.rootOutput;
 const configDir = argv.configDir;
+const codeSplittingOff = argv.codeSplittingOff;
+const extractCssOff = argv.extractCssOff;
 
 let appPerPort = true;
 let onlyPack = false;
@@ -59,6 +61,7 @@ function setupMiddleware(serverApp, compiler) {
     headers: { 'Access-Control-Allow-Origin': '*' }
   });
   serverApp.use(webpackMiddlewareInstance);
+  serverApp.use(webpackHotMiddleware(compiler))
 }
 
 function runServer(serverApp, port, servePath) {


### PR DESCRIPTION
This fixes hot reload as well as finishes implementing some half finished features for dev. Here is an overview of the changes.
* Add command line argument "--hot" to indicate hot reload for dev
* Add command line argument "--codeSplittingOff" to disable code splitting for dev
* Add command line argument "--extractCssOff" to disable css extraction in dev 
* Disable code splitting and Css extraction if flag --hot is passed
* Adds webpack hot middleware and HMR plugin if --hot is passed
* Renames webpack.hot.js to webpack.dev.js because hot is optional
* Renames executable scripts to `atomic-webpack-dev`